### PR TITLE
Moved focus request out of the game loop

### DIFF
--- a/src/main/java/edu/csueastbay/cs401/classic/GameController.java
+++ b/src/main/java/edu/csueastbay/cs401/classic/GameController.java
@@ -5,6 +5,7 @@ import edu.csueastbay.cs401.pong.Puckable;
 import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
@@ -37,7 +38,7 @@ public class GameController implements Initializable {
     @Override
     public void initialize(URL url, ResourceBundle resourceBundle) {
         game = new ClassicPong(VICTORY_SCORE, FIELD_WIDTH, FIELD_HEIGHT);
-
+        Platform.runLater(()->fieldPane.requestFocus());
         addGameElementsToField();
         setUpTimeline();
 
@@ -74,7 +75,6 @@ public class GameController implements Initializable {
         timeline = new Timeline(new KeyFrame(Duration.millis(10), new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent actionEvent) {
-                fieldPane.requestFocus();
                 game.move();
                 playerOneScore.setText(Integer.toString(game.getPlayerScore(1)));
                 playerTwoScore.setText(Integer.toString(game.getPlayerScore(2)));


### PR DESCRIPTION
Repeated focus requests make it difficult for other Games to maintain focus, so I moved the request out of the game loop and into a Runnable for Platform.runLater.